### PR TITLE
feat/added-shortcut-to-toggle-ai-panel

### DIFF
--- a/UI/main.py
+++ b/UI/main.py
@@ -1,6 +1,7 @@
 import sys
 from PyQt6.QtWidgets import QApplication, QMainWindow, QDockWidget, QTextEdit, QPushButton, QVBoxLayout, QWidget
 from PyQt6.QtCore import Qt
+from PyQt6.QtGui import QKeySequence
 
 from eric7.UI.ai_core import ask_ai
 
@@ -44,6 +45,14 @@ class MainWindow(QMainWindow):
         # Додаємо панель AI
         self.ai_panel = AIAssistantPanel(self)
         self.addDockWidget(Qt.DockWidgetArea.RightDockWidgetArea, self.ai_panel)
+
+        # Add keyboard shortcut to toggle AI panel
+        self.toggle_ai_shortcut = QShortcut(QKeySequence("Ctrl+Shift+A"), self)
+        self.toggle_ai_shortcut.activated.connect(self.toggle_ai_panel)
+
+    def toggle_ai_panel(self):
+        is_visible = self.ai_panel.isVisible()
+        self.ai_panel.setVisible(not is_visible)
 
 if __name__ == "__main__":
     app = QApplication(sys.argv)


### PR DESCRIPTION
Fixed #16

### What the PR does.
This includes the use of the key sequence `Ctrl`+`Shift`+`A` to toggle the visibility of the AI Assistant panel 
— **if the panel is hidden, the shortcut shows it; if it's visible, the shortcut hides it.**

### Changes Made
- Introduced a `QShortcut` bound to `Ctrl`+`Shift`+`A`
- Implemented the `toggle_ai_panel()` method in the `MainWindow` class
- The shortcut toggles the AI panel: shows it if hidden, hides it if visible

### How to Test
1. Run the application.
2. Use `Ctrl`+`Shift`+`A` to toggle the AI Assistant panel.
3. Confirm that the panel opens when hidden and closes when shown.
4. Repeat multiple times to verify consistent behavior.

